### PR TITLE
Removed semicolon from rollback

### DIFF
--- a/lib/knex.js
+++ b/lib/knex.js
@@ -169,7 +169,7 @@ function promisifyTransaction (client) {
       ]);
 
       transaction.rollback = function (conn, error) {
-        return this.query(conn, 'ROLLBACK;', error ? 2 : 1, error)
+        return this.query(conn, 'ROLLBACK', error ? 2 : 1, error)
           .timeout(5000)
           .catch(Promise.TimeoutError, () => {
             this._resolver();


### PR DESCRIPTION
First of all, I am not sure if this breaks anything for other database implementations.

However, `ROLLBACK;` (with semicolon) causes `ROLLBACK; - ORA-02181: invalid option to ROLLBACK WORK` for oracle database (I am using 12c).